### PR TITLE
issue #82

### DIFF
--- a/tests/fixtures/ticker_price.yaml
+++ b/tests/fixtures/ticker_price.yaml
@@ -7,16 +7,16 @@ interactions:
       Authorization: [Token 0000000000000000000000000000000000000000]
       Connection: [keep-alive]
       Content-Type: [application/json]
-      User-Agent: [tiingo-python-client 0.3.2]
+      User-Agent: [tiingo-python-client 0.5.0]
     method: GET
-    uri: https://api.tiingo.com/tiingo/daily/GOOGL/prices?format=json&frequency=daily
+    uri: https://api.tiingo.com/tiingo/daily/GOOGL/prices?format=json&resampleFreq=daily
   response:
-    body: {string: '[{"adjClose":993.64,"adjHigh":994.26,"adjLow":978.51,"adjOpen":980.0,"adjVolume":1490744,"close":993.64,"date":"2017-10-06T00:00:00+00:00","divCash":0.0,"high":994.26,"low":978.51,"open":980.0,"splitFactor":1.0,"volume":1490744}]'}
+    body: {string: '[{"adjClose":1037.29,"adjHigh":1044.65,"adjLow":1026.05,"adjOpen":1031.47,"adjVolume":1644794,"close":1037.29,"date":"2018-04-12T00:00:00+00:00","divCash":0.0,"high":1044.65,"low":1026.05,"open":1031.47,"splitFactor":1.0,"volume":1644794}]'}
     headers:
       Allow: ['GET, HEAD, OPTIONS']
-      Content-Length: ['229']
+      Content-Length: ['239']
       Content-Type: [application/json]
-      Date: ['Sun, 08 Oct 2017 10:17:18 GMT']
+      Date: ['Fri, 13 Apr 2018 02:42:05 GMT']
       Server: [nginx/1.10.1]
       Vary: ['Accept, Cookie']
       X-Frame-Options: [SAMEORIGIN]

--- a/tests/fixtures/ticker_price_weekly.yaml
+++ b/tests/fixtures/ticker_price_weekly.yaml
@@ -1,0 +1,24 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [Token 0000000000000000000000000000000000000000]
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [tiingo-python-client 0.5.0]
+    method: GET
+    uri: https://api.tiingo.com/tiingo/daily/GOOGL/prices?format=json&resampleFreq=weekly&startDate=2018-01-05&endDate=2018-01-19
+  response:
+    body: {string: '[{"date":"2018-01-05T00:00:00.000Z","close":1110.29,"high":1113.58,"low":1053.02,"open":1053.02,"volume":5889084,"adjClose":1110.29,"adjHigh":1113.58,"adjLow":1053.02,"adjOpen":1053.02,"adjVolume":5889084,"divCash":0.0,"splitFactor":1.0},{"date":"2018-01-12T00:00:00.000Z","close":1130.65,"high":1131.3,"low":1103.98,"open":1111.0,"volume":6529655,"adjClose":1130.65,"adjHigh":1131.3,"adjLow":1103.98,"adjOpen":1111.0,"adjVolume":6529655,"divCash":0.0,"splitFactor":1.0},{"date":"2018-01-19T00:00:00.000Z","close":1135.97,"high":1148.88,"low":1123.49,"open":1140.31,"volume":4470611,"adjClose":1135.97,"adjHigh":1148.88,"adjLow":1123.49,"adjOpen":1140.31,"adjVolume":4470611,"divCash":0.0,"splitFactor":1.0}]'}
+    headers:
+      Allow: ['GET, HEAD, OPTIONS']
+      Content-Length: ['708']
+      Content-Type: [application/json]
+      Date: ['Fri, 13 Apr 2018 14:46:47 GMT']
+      Server: [nginx/1.10.1]
+      Vary: ['Accept, Cookie']
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/ticker_price_with_date.yaml
+++ b/tests/fixtures/ticker_price_with_date.yaml
@@ -7,16 +7,16 @@ interactions:
       Authorization: [Token 0000000000000000000000000000000000000000]
       Connection: [keep-alive]
       Content-Type: [application/json]
-      User-Agent: [tiingo-python-client 0.3.2]
+      User-Agent: [tiingo-python-client 0.5.0]
     method: GET
-    uri: https://api.tiingo.com/tiingo/daily/GOOGL/prices?format=json&frequency=daily&startDate=2015-01-01&endDate=2015-01-05
+    uri: https://api.tiingo.com/tiingo/daily/GOOGL/prices?format=json&resampleFreq=daily&startDate=2015-01-01&endDate=2015-01-05
   response:
     body: {string: '[{"date":"2015-01-02T00:00:00.000Z","close":529.55,"high":535.8,"low":527.88,"open":532.6,"volume":1327870,"adjClose":529.55,"adjHigh":535.8,"adjLow":527.88,"adjOpen":532.6,"adjVolume":1327870,"divCash":0.0,"splitFactor":1.0},{"date":"2015-01-05T00:00:00.000Z","close":519.46,"high":527.9899,"low":517.75,"open":527.15,"volume":2059119,"adjClose":519.46,"adjHigh":527.9899,"adjLow":517.75,"adjOpen":527.15,"adjVolume":2059119,"divCash":0.0,"splitFactor":1.0}]'}
     headers:
       Allow: ['GET, HEAD, OPTIONS']
       Content-Length: ['459']
       Content-Type: [application/json]
-      Date: ['Sun, 08 Oct 2017 10:17:25 GMT']
+      Date: ['Fri, 13 Apr 2018 02:42:06 GMT']
       Server: [nginx/1.10.1]
       Vary: ['Accept, Cookie']
       X-Frame-Options: [SAMEORIGIN]

--- a/tests/fixtures/ticker_price_with_date_csv.yaml
+++ b/tests/fixtures/ticker_price_with_date_csv.yaml
@@ -7,9 +7,9 @@ interactions:
       Authorization: [Token 0000000000000000000000000000000000000000]
       Connection: [keep-alive]
       Content-Type: [application/json]
-      User-Agent: [tiingo-python-client 0.3.2]
+      User-Agent: [tiingo-python-client 0.5.0]
     method: GET
-    uri: https://api.tiingo.com/tiingo/daily/GOOGL/prices?format=csv&frequency=daily&startDate=2015-01-01&endDate=2015-01-05
+    uri: https://api.tiingo.com/tiingo/daily/GOOGL/prices?format=csv&resampleFreq=daily&startDate=2015-01-01&endDate=2015-01-05
   response:
     body: {string: 'date,close,high,low,open,volume,adjClose,adjHigh,adjLow,adjOpen,adjVolume,divCash,splitFactor
 
@@ -17,12 +17,12 @@ interactions:
 
         2015-01-05,519.46,527.9899,517.75,527.15,2059119,519.46,527.9899,517.75,527.15,2059119,0.0,1.0
 
-'}
+        '}
     headers:
       Allow: ['GET, HEAD, OPTIONS']
       Content-Length: ['276']
       Content-Type: [text/csv]
-      Date: ['Sun, 08 Oct 2017 10:17:24 GMT']
+      Date: ['Fri, 13 Apr 2018 02:42:06 GMT']
       Server: [nginx/1.10.1]
       Vary: ['Accept, Cookie']
       X-Frame-Options: [SAMEORIGIN]

--- a/tests/test_tiingo.py
+++ b/tests/test_tiingo.py
@@ -65,7 +65,7 @@ class TestTickerPrices(TestCase):
 
     @vcr.use_cassette('tests/fixtures/ticker_price_weekly.yaml')
     def test_ticker_price(self):
-        """Test that EOD Prices Endpoint works"""
+        """Test that weekly frequency works"""
         prices = self._client.get_ticker_price("GOOGL", startDate='2018-01-05',
                     endDate='2018-01-19', frequency='weekly')
         assert len(prices) == 3

--- a/tests/test_tiingo.py
+++ b/tests/test_tiingo.py
@@ -63,6 +63,14 @@ class TestTickerPrices(TestCase):
         assert len(prices) == 1
         assert prices[0].get('adjClose')
 
+    @vcr.use_cassette('tests/fixtures/ticker_price_weekly.yaml')
+    def test_ticker_price(self):
+        """Test that EOD Prices Endpoint works"""
+        prices = self._client.get_ticker_price("GOOGL", startDate='2018-01-05',
+                    endDate='2018-01-19', frequency='weekly')
+        assert len(prices) == 3
+        assert prices[0].get('adjClose')
+
     @vcr.use_cassette('tests/fixtures/ticker_price.yaml')
     def test_ticker_price_as_object(self):
         """Test that EOD Prices Endpoint works"""

--- a/tiingo/api.py
+++ b/tiingo/api.py
@@ -136,7 +136,7 @@ class TiingoClient(RestClient):
         url = "tiingo/daily/{}/prices".format(ticker)
         params = {
             'format': fmt if fmt != "object" else 'json',  # conversion local
-            'frequency': frequency
+            'resampleFreq': frequency
         }
 
         if startDate:


### PR DESCRIPTION
Resolves #82 and affected vcr files have been regenerated.  Note in order to regenerate the test fixtures I had to set the api key through the environment variable to my personal api key, which ended up putting my api key into the `.yaml` files.  I had to then edit them by hand and replace my api key with `0000000000000000000000000000000000000000` before committing them.  After doing that I was able to set the api key to `0*30` and rerun `py.test`, which was successful, since this key had been stored in the `.yaml` files.  It might be helpful to put something in the `CONTRIBUTING.rst` file regarding this.