### PR TITLE
Fix #126: Cache Pip Dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ python:
   - 2.7
   # - 2.6
 
+cache: pip
+
 env:
   - WITH_PANDAS=false
   - WITH_PANDAS=true


### PR DESCRIPTION
This PR will reduce the build times in Travis (our Continuous Integration tool) by avoiding the need to redownload all the pip dependencies on every build.