### PR TITLE
Remove python 3.7 from CI Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ install:
 
 language: python
 python:
-  - 3.7
   - 3.6
   - 3.5
   - 3.4


### PR DESCRIPTION
Travis is unable to find a suitable binary from which to pull python 3.7 from (we're getting HTTP 403 errors), so I'm removing it from CI until that issue is resolved.