### PR TITLE
Fixed Bug: KeyError: <ticker> for batch query

### DIFF
--- a/tiingo/api.py
+++ b/tiingo/api.py
@@ -263,7 +263,7 @@ class TiingoClient(RestClient):
                     df = pd.DataFrame(response.json())
                     df.index = df['date']
                     df.rename(index=str, columns={metric_name: stock}, inplace=True)
-                    prices = pd.concat([prices, df[stock]], axis=1)
+                    prices = pd.concat([prices, df], axis=1)
             prices.index = pd.to_datetime(prices.index)
             return prices
         else:


### PR DESCRIPTION
For passing tickers as list for e.g. ['AAPL, 'GOOGL'], the concat operation results in KeyError: 'AAPL', because the df does not contain this index
