### PR TITLE
[feature] Rename internal sources URL parameter to source

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,9 +2,9 @@
 History
 =======
 
-0.11.x (2019-XX-XX)
+0.11.x (2019-09-XX)
 --------------------
-* Update me as new features are added
+* [/news] Internally rename sources parameter to "source", ensure lists are passed as comma separated values
 
 0.10.x (2019-05-11)
 --------------------

--- a/tests/fixtures/news.yaml
+++ b/tests/fixtures/news.yaml
@@ -9,7 +9,7 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [tiingo-python-client 0.3.2]
     method: GET
-    uri: https://api.tiingo.com/tiingo/news?limit=1&offset=0&sortBy=publishedDate&tickers=aapl&tickers=googl&sources=washingtonpost.com&sources=altcointoday.com&tags=Technology&tags=Bitcoin&startDate=2016-01-01&endDate=2017-08-31
+    uri: https://api.tiingo.com/tiingo/news?limit=1&offset=0&sortBy=publishedDate&tickers=aapl&tickers=googl&source=cnbc.com,altcointoday.com&tags=Technology&tags=Bitcoin&startDate=2016-01-01&endDate=2017-08-31
   response:
     body: {string: '[{
     "publishedDate": "2016-01-11T23:13:00Z",

--- a/tests/fixtures/news.yaml
+++ b/tests/fixtures/news.yaml
@@ -7,7 +7,7 @@ interactions:
       Authorization: [Token 0000000000000000000000000000000000000000]
       Connection: [keep-alive]
       Content-Type: [application/json]
-      User-Agent: [tiingo-python-client 0.3.2]
+      User-Agent: [tiingo-python-client 0.11.0]
     method: GET
     uri: https://api.tiingo.com/tiingo/news?limit=1&offset=0&sortBy=publishedDate&tickers=aapl&tickers=googl&source=cnbc.com,altcointoday.com&tags=Technology&tags=Bitcoin&startDate=2016-01-01&endDate=2017-08-31
   response:

--- a/tests/test_tiingo.py
+++ b/tests/test_tiingo.py
@@ -155,7 +155,7 @@ class TestNews(TestCase):
             "tags": ["Technology", "Bitcoin"],
             "startDate": "2016-01-01",
             "endDate": "2017-08-31",
-            "sources": ['washingtonpost.com', 'altcointoday.com'],
+            "sources": ['cnbc.com', 'altcointoday.com'],
             "limit": self.num_articles
         }
 

--- a/tiingo/api.py
+++ b/tiingo/api.py
@@ -299,7 +299,7 @@ class TiingoClient(RestClient):
             'offset': offset,
             'sortBy': sortBy,
             'tickers': tickers,
-            'sources': sources,
+            'source': (",").join(sources),
             'tags': tags,
             'startDate': startDate,
             'endDate': endDate


### PR DESCRIPTION
## Summary of Changes

- Fix the "sources" URL parameter to be `source`, per the latest API documentation [here](https://api.tiingo.com/documentation/news)
- Update tests + documentation

## Motivation

- Addresses #137, thanks @scolemann for the bug report.
