### PR TITLE
[ci] Remove python 3.4 from the travis build due to requests deprecation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.11.x (2019-09-XX)
 --------------------
 * [/news] Internally rename sources parameter to "source", ensure lists are passed as comma separated values
+* CI: Remove Travis testing for Python 3.4
 
 0.10.x (2019-05-11)
 --------------------


### PR DESCRIPTION
# Summary of Changes

Since `requests` doesn't support python 3.4 any longer, the latest version of `tiingo` will not run tests on python 3.4 either.

<a href="https://cl.ly/793f24d30769" target="_blank"><img src="https://d2ddoduugvun08.cloudfront.net/items/0C3l0h2r270P1f2Z1C45/Image%202019-09-01%20at%209.01.07%20PM.png" style="display: block;height: auto;width: 100%;"/></a>

https://travis-ci.org/hydrosquall/tiingo-python/jobs/579589171 (Follow up to #325 )