### PR TITLE
[fix] Address pandas future warning about sorting in pd.DataFrame.concat

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.13.0 (2019-11-XX - Unreleased)
 --------------------------------
-* Update me with new features!
+* Minor: Address Pandas Future Warning for sorting in pd.concat (#392)
 
 0.12.0 (2019-10-20)
 --------------------

--- a/tiingo/__version__.py
+++ b/tiingo/__version__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.12.0'
+__version__ = '0.13.0'

--- a/tiingo/api.py
+++ b/tiingo/api.py
@@ -267,7 +267,7 @@ class TiingoClient(RestClient):
                     df = pd.DataFrame(response.json())
                     df.index = df['date']
                     df.rename(index=str, columns={metric_name: stock}, inplace=True)
-                    prices = pd.concat([prices, df[stock]], axis=1)
+                    prices = pd.concat([prices, df[stock]], axis=1, sort=True)
             prices.index = pd.to_datetime(prices.index)
             return prices
         else:


### PR DESCRIPTION
Fixes #392, see github issue thread for more context.