### PR TITLE
[testing] Replace deprecated assertRaisesRegexp with assertRaisesRegex

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,7 +13,7 @@ History
 * Feature: Add option to request data in csv format in get_dataframe method potentially boosting speed up to 4-5x. (#523)
 * Minor: bumped library dependencies, in particular cryptography
 * Development: Dropped official support for Python 3.5, replaced with 3.7
-* Development: Publish library with Github Actions instead of Travis (#546
+* Development: Publish library with Github Actions instead of Travis (#546)
 
 0.12.0 (2019-10-20)
 --------------------

--- a/tests/test_restclient.py
+++ b/tests/test_restclient.py
@@ -34,7 +34,14 @@ class TestRestClient(TestCase):
 
     # Test 404 error
     def test_invalid_url(self):
-        with self.assertRaisesRegex(RestClientError, "404"),\
+
+        #  Suppress deprecation warning in python 3
+        if hasattr(self, 'assertRaisesRegex'):
+            assertFunc = self.assertRaisesRegex
+        else:
+            assertFunc = self.assertRaisesRegexp
+
+        with assertFunc(RestClientError, "404"),\
                 vcr.use_cassette('tests/fixtures/invalid_url.yaml'):
             # Should return 404 error
             self._client._request('GET', "bing_is_great")
@@ -66,7 +73,14 @@ class TestRestClientWithSession(TestCase):
 
     # Test 404 error
     def test_invalid_url(self):
-        with self.assertRaisesRegex(RestClientError, "404"),\
+
+         #  Suppress deprecation warning in python 3
+        if hasattr(self, 'assertRaisesRegex'):
+            assertFunc = self.assertRaisesRegex
+        else:
+            assertFunc = self.assertRaisesRegexp
+
+        with assertFunc(RestClientError, "404"),\
                 vcr.use_cassette('tests/fixtures/invalid_url.yaml'):
             # Should return 404 error
             self._client._request('GET', "bing_is_great")

--- a/tests/test_restclient.py
+++ b/tests/test_restclient.py
@@ -34,7 +34,7 @@ class TestRestClient(TestCase):
 
     # Test 404 error
     def test_invalid_url(self):
-        with self.assertRaisesRegexp(RestClientError, "404"),\
+        with self.assertRaisesRegex(RestClientError, "404"),\
                 vcr.use_cassette('tests/fixtures/invalid_url.yaml'):
             # Should return 404 error
             self._client._request('GET', "bing_is_great")
@@ -66,7 +66,7 @@ class TestRestClientWithSession(TestCase):
 
     # Test 404 error
     def test_invalid_url(self):
-        with self.assertRaisesRegexp(RestClientError, "404"),\
+        with self.assertRaisesRegex(RestClientError, "404"),\
                 vcr.use_cassette('tests/fixtures/invalid_url.yaml'):
             # Should return 404 error
             self._client._request('GET', "bing_is_great")


### PR DESCRIPTION
## Summary of Changes

- Follows the library deprecation recommendation for an API that has been renamed, but only in Python 3. (Keep the old method for python 2).

 https://travis-ci.org/github/hydrosquall/tiingo-python/jobs/749281327

```
  /home/travis/build/hydrosquall/tiingo-python/tests/test_restclient.py:69: DeprecationWarning: Please use assertRaisesRegex instead.
    with self.assertRaisesRegexp(RestClientError, "404"),\
```