### PR TITLE
Update get_news() to work when no `sources` are provided.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,3 +16,4 @@ Contributors
 * Davis Thames
 * Nima Yazdanmehr
 * Michael MacCormack
+* David Minnen

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 --------------------------------
 * Feature (Name #Number)
 * Development: Run tests in Github Actions instead of Travis.org
+* [/news] Fix bug in get_news() when sources list is empty (#566)
 
 0.13.0 (2020-12-12)
 --------------------------------

--- a/tests/fixtures/news_empty_sources.yaml
+++ b/tests/fixtures/news_empty_sources.yaml
@@ -1,0 +1,47 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Token 0000000000000000000000000000000000000000
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - tiingo-python-client 0.13.0
+    method: GET
+    uri: https://api.tiingo.com/tiingo/news?limit=1&offset=0&sortBy=publishedDate&tickers=aapl&tickers=googl&tags=Technology&tags=Bitcoin&startDate=2016-01-01&endDate=2017-08-31&onlyWithTickers=False
+  response:
+    body:
+      string: "[{\"source\":\"finance.yahoo.com\",\"description\":\"Elon Musk disupted\
+        \ claims of a Gigafactory Bitcoin ATM, BitMEX hired a head of compliance and\
+        \ there's nearly $1.5 billion worth of Ethereum-tokenized bitcoin.\",\"tags\"\
+        :[\"Bitcoin\",\"CryptoCurrency\",\"Defi\",\"Ethereum\",\"Stock\",\"Technology\"\
+        ,\"Unknown Sector\"],\"tickers\":[\"defi\",\"goog\",\"googl\"],\"publishedDate\"\
+        :\"2020-10-12T16:45:48Z\",\"url\":\"https://finance.yahoo.com/news/blockchain-bites-bitcoin-ethereum-whos-164548067.html\"\
+        ,\"title\":\"Blockchain Bites: Bitcoin on Ethereum \u2013 The Whos, Whats\
+        \ and Whys\",\"crawlDate\":\"2020-10-12T17:57:59.290788Z\",\"id\":29484963}]"
+    headers:
+      allow:
+      - GET, HEAD, OPTIONS
+      content-length:
+      - '598'
+      content-type:
+      - application/json
+      date:
+      - Mon, 11 Jan 2021 04:16:10 GMT
+      server:
+      - nginx/1.14.0 (Ubuntu)
+      vary:
+      - Cookie, Origin
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_tiingo.py
+++ b/tests/test_tiingo.py
@@ -183,6 +183,15 @@ class TestNews(TestCase):
         for article in articles:
             assert all(key in article for key in self.article_keys)
 
+    @vcr.use_cassette('tests/fixtures/news_empty_sources.yaml')
+    def test_get_news_empty_sources(self):
+        search_params = self.search_params.copy()
+        search_params['sources'] = []
+        articles = self._client.get_news(**search_params)
+        assert len(articles) == self.num_articles
+        for article in articles:
+            assert all(key in article for key in self.article_keys)
+
     @vcr.use_cassette('tests/fixtures/news_bulk.yaml')
     def test_get_news_bulk(self):
         """Fails because this API key lacks institutional license"""

--- a/tiingo/api.py
+++ b/tiingo/api.py
@@ -338,7 +338,7 @@ class TiingoClient(RestClient):
             'offset': offset,
             'sortBy': sortBy,
             'tickers': tickers,
-            'source': (",").join(sources),
+            'source': (",").join(sources) if sources else None,
             'tags': tags,
             'startDate': startDate,
             'endDate': endDate,


### PR DESCRIPTION
🎉 Hello there 🎉! Thanks for taking the time to contribute to `Tiingo-Python`!

## Summary of Changes

- What is the motivation / context for this change?
Fix get_news() with empty `sources` list, which is the default value. Currently, tiingo won't return any news articles since `sources = ""` in the request (#566).

- Is this a bugfix or a feature?
bug fix

- What does this change / fix? (Link to Github Issue page if applicable)
https://github.com/hydrosquall/tiingo-python/issues/566

## Checklist

- [x] Code follows the style guidelines of this project
- [x] Added tests for new functionality
- [x] Update `HISTORY.rst` with an entry summarizing your change
- [?] Tag a project maintainer
