### PR TITLE
build: replace python 3.6 testing with 3.9

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.7', '3.8', '3.9']
         WITH_PANDAS: [false, true]
 
     steps:


### PR DESCRIPTION
CI was failing because Python 3.6 is no longer available in the test images. Replacing it with 3.9 instead.

<img width="1681" alt="image" src="https://user-images.githubusercontent.com/9020979/228395415-5d6b0cdc-9369-452f-a8e6-257952b1e1ad.png">
