### PR TITLE
feat: apply latest black python formatting

### DIFF
--- a/tiingo/api.py
+++ b/tiingo/api.py
@@ -265,7 +265,6 @@ class TiingoClient(RestClient):
         frequency="daily",
         fmt="json",
     ):
-
         """Return a pandas.DataFrame of historical prices for one or more ticker symbols.
 
         By default, return latest EOD Composite Price for a list of stock tickers.

--- a/tiingo/wsclient.py
+++ b/tiingo/wsclient.py
@@ -40,7 +40,6 @@ class TiingoWebsocketClient:
     """
 
     def __init__(self, config=None, endpoint=None, on_msg_cb=None):
-
         self._base_url = "wss://api.tiingo.com"
         self.config = {} if config is None else config
 


### PR DESCRIPTION

## Summary of Changes

After the latest `black` update, https://github.com/hydrosquall/tiingo-python/pull/827 , some files need to be reformatted to pass in CI. The issue wasn't noticed before since the test matrix was failing on the missing Python 3.6 version.

## Checklist

- [x] Code follows the style guidelines of this project
- [ ] Added tests for new functionality (N/A)
- [ ] Update `HISTORY.rst` with an entry summarizing your change (N/A, no functionality change)
