### PR TITLE
build: remove pytest-runner (fixes #749)

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,7 +9,6 @@ cryptography==40.0.1
 Sphinx==5.3.0
 PyYAML==6.0
 pytest==7.2.2
-pytest-runner==6.0.0
 vcrpy==2.1.1
 twine==4.0.2
 black==23.1.0

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,6 @@ requirements = [
     'websocket-client'
 ]
 
-setup_requirements = [
-    'pytest-runner',
-]
-
 test_requirements = [
     'pytest',
     'vcrpy',
@@ -76,5 +72,4 @@ setup(
     ],
     test_suite='tests',
     tests_require=test_requirements,
-    setup_requires=setup_requirements,
 )


### PR DESCRIPTION
## Summary of Changes

Fixes https://github.com/hydrosquall/tiingo-python/issues/749

I don't think we actually use pytest-runner to invoke our tests, so it's better just to remove this entirely if it's creating security warnings.

## Checklist

- [ ] Code follows the style guidelines of this project
- [ ] Added tests for new functionality
- [ ] Update `HISTORY.rst` with an entry summarizing your change
- [ ] Tag a project maintainer
