### PR TITLE
Release/0.15.1

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,5 +1,7 @@
 # This workflows will upload a Python Package using Twine when a release is created
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# On using trusted publishers:
+# https://docs.pypi.org/trusted-publishers/using-a-publisher/
 
 name: Upload Python Package
 
@@ -9,7 +11,9 @@ on:
 
 jobs:
   deploy:
-
+    environment: release
+      permissions:
+      id-token: write
     runs-on: ubuntu-latest
 
     steps:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 0.16.0 (2024-XX - Unreleased)
 --------------------------------
 
-0.15.0 (2024-05-25)
+0.15.1 (2024-05-25)
 --------------------------------
 
 * Feature: Support websockets client / endpoints (#508)
@@ -14,6 +14,7 @@ History
 * CI: fixed CodeCov upload (#856)
 * CI: Add CodeQL for static analysis scanning (#785)
 * Minor: bumped development / examples dependencies
+* Minor: Switch to trusted publisher workflow
 
 0.14.0 (2021-03-06)
 --------------------------------

--- a/tiingo/__version__.py
+++ b/tiingo/__version__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "0.15.0"
+__version__ = "0.15.1"


### PR DESCRIPTION
## Motivation

Build step for publishing v0.15.0 errored as PyPI password-based publishing is no longer supported. This fixes it using the info on https://docs.pypi.org/trusted-publishers/using-a-publisher/ . 