### PR TITLE
Remove pkg_resources import (deprecated module)

### DIFF
--- a/tiingo/api.py
+++ b/tiingo/api.py
@@ -26,8 +26,7 @@ try:
 except ImportError:
     pandas_is_installed = False
 
-VERSION = pkg_resources.get_distribution("tiingo").version
-
+from .__version__ import __version__ as VERSION
 
 # These methods enable python 2 + 3 compatibility.
 def get_zipfile_from_response(response):

--- a/tiingo/api.py
+++ b/tiingo/api.py
@@ -6,7 +6,6 @@ import json
 import os
 import re
 import sys
-import pkg_resources
 from zipfile import ZipFile
 
 import requests

--- a/tiingo/api.py
+++ b/tiingo/api.py
@@ -18,6 +18,8 @@ from tiingo.exceptions import (
     MissingRequiredArgumentError,
 )
 
+from tiingo.__version__ import __version__ as VERSION
+
 try:
     import pandas as pd
 
@@ -25,7 +27,6 @@ try:
 except ImportError:
     pandas_is_installed = False
 
-from .__version__ import __version__ as VERSION
 
 # These methods enable python 2 + 3 compatibility.
 def get_zipfile_from_response(response):


### PR DESCRIPTION
## Summary of Changes

- `pkg_resources` is deprecated and causing import warnings in recent python versions
- `pkg_resources` was used only to fetch the package version as `VERSION`
- The version can be fetched directly from the `__version__` submodule
- There is no need for `pkg_resources` or `importlib.metadata`
- Fixes #1071 

## Checklist

- [x] Code follows the style guidelines of this project
- [ ] Added tests for new functionality
- [ ] Update `HISTORY.rst` with an entry summarizing your change
- [ ] Tag a project maintainer
