### PR TITLE
chore: fix deprecated github actions steps for publishing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,9 +19,9 @@ jobs:
         WITH_PANDAS: [false, true]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,7 +33,7 @@ jobs:
         python setup.py sdist bdist_wheel
 
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -52,7 +52,7 @@ jobs:
       id-token: write
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/


### PR DESCRIPTION
## Summary of Changes

- #1074 is erroring on publish because of https://github.com/orgs/community/discussions/152695
- See job log: https://github.com/hydrosquall/tiingo-python/actions/runs/14282804356/job/40034313325


